### PR TITLE
return more specific error for 416

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -519,6 +519,9 @@ func (ce *Entry) Download(ctx context.Context) ReaderAtCloser {
 			return nil, errors.WithStack(err)
 		}
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			if resp.StatusCode == http.StatusRequestedRangeNotSatisfiable {
+				return nil, errors.Errorf("invalid status response %v for %s, range: %v", resp.Status, ce.URL, req.Header.Get("Range"))
+			}
 			return nil, errors.Errorf("invalid status response %v for %s", resp.Status, ce.URL)
 		}
 		if offset != 0 {


### PR DESCRIPTION
We have some reports of 416 errors returned:

```
#77 ERROR: failed to copy: invalid status response 416 The range specified is invalid for the current size of the resource. for https://ki6cacprodeus1file5.blob.core.windows.net/2ff2ce0399e5464697755b110c91788d/0548797b8d9bec11a22a14cb6534c5d2?sv=2019-07-07&sr=b&sig=GC9svpeloQN12Lc%2F9drLoxs3voi09SviePsHyVb15Uo%3D&se=2022-03-09T20%3A18%3A03Z&sp=r&rscl=x-e2eid-84273bf6-bbd54c56-87536ceb-5869deca
```

Not really clear what is the issue in here but would help to get more information of what the actual request was. Maybe it appears on specific offset or there is an issue with the end bytes.

fyi @dhadka

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>