### PR TITLE
add support for listing active keys via REST API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,4 +41,6 @@ jobs:
         uses: crazy-max/ghaction-github-runtime@v3
       -
         name: Test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: go test -v .

--- a/allkeys_test.go
+++ b/allkeys_test.go
@@ -1,0 +1,50 @@
+package actionscache
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllKeys(t *testing.T) {
+	ctx := context.TODO()
+
+	ghToken, ok := os.LookupEnv("GITHUB_TOKEN")
+	if !ok || ghToken == "" {
+		t.Log("GITHUB_TOKEN not set")
+		t.SkipNow()
+	}
+	ghRepo, ok := os.LookupEnv("GITHUB_REPOSITORY")
+	if !ok || ghRepo == "" {
+		t.Log("GITHUB_REPOSITORY not set")
+		t.SkipNow()
+	}
+
+	c, err := TryEnv(Opt{})
+	require.NoError(t, err)
+	if c == nil {
+		t.SkipNow()
+	}
+
+	api, err := NewRestAPI(ghRepo, ghToken, Opt{})
+	require.NoError(t, err)
+
+	k := "allkeys_test_" + newID()
+
+	m, err := c.AllKeys(ctx, api, "allkeys_test_")
+	require.NoError(t, err)
+
+	_, ok = m[k]
+	require.False(t, ok)
+
+	err = c.Save(ctx, k, NewBlob([]byte("foobar")))
+	require.NoError(t, err)
+
+	m, err = c.AllKeys(ctx, api, "allkeys_test_")
+	require.NoError(t, err)
+
+	_, ok = m[k]
+	require.True(t, ok)
+}

--- a/rest.go
+++ b/rest.go
@@ -1,0 +1,111 @@
+package actionscache
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+const (
+	apiURL  = "https://api.github.com"
+	perPage = 100
+)
+
+type RestAPI struct {
+	repo  string
+	token string
+	opt   Opt
+}
+
+type CacheKey struct {
+	ID           int    `json:"id"`
+	Ref          string `json:"ref"`
+	Key          string `json:"key"`
+	Version      string `json:"version"`
+	LastAccessed string `json:"last_accessed_at"`
+	CreatedAt    string `json:"created_at"`
+	SizeInBytes  int    `json:"size_in_bytes"`
+}
+
+func NewRestAPI(repo, token string, opt Opt) (*RestAPI, error) {
+	opt = optsWithDefaults(opt)
+	return &RestAPI{
+		repo:  repo,
+		token: token,
+		opt:   opt,
+	}, nil
+}
+
+func (r *RestAPI) httpReq(ctx context.Context, method string, url *url.URL) (*http.Request, error) {
+	req, err := http.NewRequest(method, url.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+r.token)
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	return req, nil
+}
+
+func (r *RestAPI) ListKeys(ctx context.Context, prefix, ref string) ([]CacheKey, error) {
+	var out []CacheKey
+	page := 1
+	for {
+		keys, total, err := r.listKeysPage(ctx, prefix, ref, page)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, keys...)
+		if total > page*perPage {
+			page++
+		} else {
+			break
+		}
+	}
+	return out, nil
+}
+
+func (r *RestAPI) listKeysPage(ctx context.Context, prefix, ref string, page int) ([]CacheKey, int, error) {
+	u, err := url.Parse(apiURL + "/repos/" + r.repo + "/actions/caches")
+	if err != nil {
+		return nil, 0, err
+	}
+	q := u.Query()
+	q.Set("per_page", strconv.Itoa(perPage))
+	if page > 0 {
+		q.Set("page", strconv.Itoa(page))
+	}
+	if prefix != "" {
+		q.Set("key", prefix)
+	}
+	if ref != "" {
+		q.Set("ref", ref)
+	}
+	u.RawQuery = q.Encode()
+
+	req, err := r.httpReq(ctx, "GET", u)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	resp, err := r.opt.Client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	dec := json.NewDecoder(resp.Body)
+	var keys struct {
+		Total  int        `json:"total_count"`
+		Caches []CacheKey `json:"actions_caches"`
+	}
+
+	if err := dec.Decode(&keys); err != nil {
+		return nil, 0, err
+	}
+
+	resp.Body.Close()
+	return keys.Caches, keys.Total, nil
+}


### PR DESCRIPTION
This allows reducing requests needed to check if
a key is still available in storage and not get hit by rate limits.