### PR TITLE
reload expired cache URLs

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -593,6 +593,7 @@ type Entry struct {
 	IsAzureBlob bool   `json:"isAzureBlob"`
 
 	client *http.Client
+	reload func(context.Context) error
 }
 
 func (ce *Entry) WriteTo(ctx context.Context, w io.Writer) error {

--- a/cache_v2.go
+++ b/cache_v2.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net/http"
 	"strings"
 	"time"
 
@@ -76,17 +77,34 @@ func (c *Cache) uploadV2(ctx context.Context, url string, b Blob) error {
 
 func (ce *Entry) downloadV2(ctx context.Context) ReaderAtCloser {
 	return toReaderAtCloser(func(offset int64) (io.ReadCloser, error) {
-		client, err := blockblob.NewClientWithNoCredential(ce.URL, azureOptions)
-		if err != nil {
-			return nil, errors.WithStack(err)
+		var retried bool
+		for {
+			client, err := blockblob.NewClientWithNoCredential(ce.URL, azureOptions)
+			if err != nil {
+				return nil, errors.WithStack(err)
+			}
+			resp, err := client.DownloadStream(ctx, &blob.DownloadStreamOptions{
+				Range: blob.HTTPRange{Offset: offset},
+			})
+			if err != nil {
+				if !retried {
+					// the URL might have expired, so we try to load it again
+					retried = true
+					var respErr *azcore.ResponseError
+					if errors.As(err, &respErr) {
+						if respErr.StatusCode == http.StatusForbidden || respErr.StatusCode == http.StatusUnauthorized {
+							Log("reload download URL because error %v", err)
+							if err := ce.reload(ctx); err != nil {
+								return nil, errors.WithStack(err)
+							}
+							continue // retry with the new URL
+						}
+					}
+				}
+				return nil, errors.WithStack(err)
+			}
+			return resp.Body, nil
 		}
-		resp, err := client.DownloadStream(ctx, &blob.DownloadStreamOptions{
-			Range: blob.HTTPRange{Offset: offset},
-		})
-		if err != nil {
-			return nil, errors.WithStack(err)
-		}
-		return resp.Body, nil
 	})
 }
 
@@ -187,6 +205,15 @@ func (c *Cache) loadV2(ctx context.Context, keys ...string) (*Entry, error) {
 	ce.URL = val.SignedDownloadURL
 	ce.IsAzureBlob = true
 	ce.client = c.opt.Client
+	ce.reload = func(ctx context.Context) error {
+		v, err := c.loadV2(ctx, keys...)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		ce.URL = v.URL
+		ce.Key = v.Key
+		return nil
+	}
 
 	return &ce, nil
 }


### PR DESCRIPTION
In some conditions, there can be a pause between the initial load of the entry (that already contains a signed download URL even though we don't need it yet) and the time the cache blob is actually downloaded at the end of the build. One such case seems to be accessing SBOM scanner layers after the main build is completed. The signed URL is only valid for 10 minutes, and if more time has passed, then the old URL may receive a 403 error.