### PR TITLE
resp.Body leak at (*Entry).Download

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -627,6 +627,7 @@ func (ce *Entry) Download(ctx context.Context) ReaderAtCloser {
 			return nil, errors.WithStack(err)
 		}
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			defer resp.Body.Close()
 			if resp.StatusCode == http.StatusRequestedRangeNotSatisfiable {
 				return nil, errors.Errorf("invalid status response %v for %s, range: %v", resp.Status, ce.URL, req.Header.Get("Range"))
 			}


### PR DESCRIPTION
Hello!

In `cache.go` method (*Entry).Download: if `resp.StatusCode` inside `ReaderAtCloser` `open` func is invalid, then `resp.Body` should be closed before exiting to avoid potential leak.

This PR adds resp.Body closing before exiting with error.