### PR TITLE
rest: close response body on decode errors

### DIFF
--- a/rest.go
+++ b/rest.go
@@ -95,6 +95,7 @@ func (r *RestAPI) listKeysPage(ctx context.Context, prefix, ref string, page int
 	if err != nil {
 		return nil, 0, err
 	}
+	defer resp.Body.Close()
 
 	dec := json.NewDecoder(resp.Body)
 	var keys struct {
@@ -106,6 +107,5 @@ func (r *RestAPI) listKeysPage(ctx context.Context, prefix, ref string, page int
 		return nil, 0, err
 	}
 
-	resp.Body.Close()
 	return keys.Caches, keys.Total, nil
 }


### PR DESCRIPTION
This change moves `resp.Body.Close()` to a deferred call immediately after a successful `Client.Do` call in `listKeysPage`.

Previously, the response body was closed only after the JSON response had been decoded successfully. If decoding failed, `listKeysPage` returned early without closing `resp.Body`.

According to the `net/http` contract, callers must close the response body when `Client.Do` succeeds. Not doing so can leak the body and may prevent the HTTP transport from reusing the connection.

Found by Linux Verification Center (linuxtesting.org) with SVACE.